### PR TITLE
Allow to specify a file path with additional sauce labs options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ testCafe
 
 Use the following environment variables to set additional configuration options:
 
- - `SAUCE_JOB` - the text that will be displayed as Job Name on SauceLabs,   
- 
+ - `SAUCE_JOB` - the text that will be displayed as Job Name on SauceLabs,
+
  - `SAUCE_BUILD` - the text that will be displayed as Build Name on SauceLabs.
- 
+
+ - `SAUCE_CONFIG_PATH` - Path to a file which contains additional job options as JSON. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions) for a full list.
+
 ## Author
 Developer Express Inc. (https://devexpress.com)

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -21,7 +21,7 @@ describe('Browser names', function () {
             .getBrowserList()
             .then(function (list) {
                 var commonBrowsers = [
-                    'Chrome@51.0:OS X 10.9',
+                    'Chrome@51.0:OS X 10.10',
                     'Firefox@45.0:Linux',
                     'Safari@9.0:OS X 10.11',
                     'Internet Explorer@9.0:Windows 7',


### PR DESCRIPTION
* this can be done by providing a file located at the path configured in the SAUCE_CONFIG_PATH environment varibale.
 * also fix failing test because saucelabs does no longer offer OS X 10.9

closes #24, fixes #19, fixes #20 