### PR TITLE
Adding SAUCE_SCREEN_RESOLUTION to set browser resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ Use the following environment variables to set additional configuration options:
 
  - `SAUCE_CONFIG_PATH` - Path to a file which contains additional job options as JSON. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions) for a full list.
  
- - `SAUCE_SCREEN_RESOLUTION` - allows to set the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information. Example:
+ - `SAUCE_SCREEN_RESOLUTION` - allows to set the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information. 
+ 
+Example:
 ```sh
 export SAUCE_SCREEN_RESOLUTION="1920x1080"
+export SAUCE_JOB="E2E TestCafe"
+export SAUCE_BUILD="Build 42"
+testcafe saucelabs:safari,saucelabs:chrome tests/
 ```
  
 ## Author

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ Use the following environment variables to set additional configuration options:
 
  - `SAUCE_CONFIG_PATH` - Path to a file which contains additional job options as JSON. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions) for a full list.
  
- - `SAUCE_SCREEN_RESOLUTION` - Set screen resolution of the browser (only works for desktop, does not work for mobile).  Example: `export SAUCE_SCREEN_RESOLUTION=1920x1080`.  See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for more info.
+ - `SAUCE_SCREEN_RESOLUTION` - allows to set the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information. Example:
+```sh
+export SAUCE_SCREEN_RESOLUTION="1920x1080"
+```
  
 ## Author
 Developer Express Inc. (https://devexpress.com)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Use the following environment variables to set additional configuration options:
  - `SAUCE_BUILD` - the text that will be displayed as Build Name on SauceLabs.
 
  - `SAUCE_CONFIG_PATH` - Path to a file which contains additional job options as JSON. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions) for a full list.
-
+ 
+ - `SAUCE_SCREEN_RESOLUTION` - Set screen resolution of the browser (only works for desktop, does not work for mobile).  Example: `export SAUCE_SCREEN_RESOLUTION=1920x1080`.  See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for more info.
+ 
 ## Author
 Developer Express Inc. (https://devexpress.com)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Use the following environment variables to set additional configuration options:
 
  - `SAUCE_CONFIG_PATH` - Path to a file which contains additional job options as JSON. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions) for a full list.
  
- - `SAUCE_SCREEN_RESOLUTION` - allows to set the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information. 
+ - `SAUCE_SCREEN_RESOLUTION` - allows setting the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information. 
  
 Example:
 ```sh

--- a/src/index.js
+++ b/src/index.js
@@ -316,7 +316,8 @@ export default {
 
         if (query.platform !== 'any')
             capabilities.platform = query.platform;
-
+        if (process.env['SAUCE_SCREEN_RESOLUTION'])
+            capabilities.screenResolution = process.env['SAUCE_SCREEN_RESOLUTION'];
         return capabilities;
     },
 


### PR DESCRIPTION
Currently been trying to set resolution via SAUCE_CONFIG_PATH.  debugging into it and looking at https://github.com/AlexanderMoskovkin/saucelabs-connector/blob/master/src/index.js#L108 this isn't the correct place to set configurations like screen resolution.  

After adding SAUCE_SCREEN_RESOLUTION locally I saw this working.  

when I ran `export SAUCE_SCREEN_RESOLUTION=2560x1600` with a example test I got the following browser:
![image](https://user-images.githubusercontent.com/5624870/50466490-c5158180-0952-11e9-947a-be6876747d1d.png)

without (defaults to 1024x768):
![image](https://user-images.githubusercontent.com/5624870/50466618-82a07480-0953-11e9-9da3-c185a2978a73.png)

