### PR TITLE
Support for capabilities override file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - "8"
   - "stable"
 
 os:

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -73,5 +73,6 @@ exports.clean = clean;
 exports.lint  = lint;
 exports.build = gulp.parallel(lint, gulp.series(clean, build));
 exports.test  = gulp.series(exports.build, testMocha, testTestcafe);
+exports.testMocha = gulp.series(exports.build, testMocha);
 
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -69,10 +69,10 @@ function testTestcafe () {
     return spawn(testCafeCmd, testCafeOpts, { NODE_PATH: PACKAGE_SEARCH_PATH });
 }
 
-exports.clean = clean;
-exports.lint  = lint;
-exports.build = gulp.parallel(lint, gulp.series(clean, build));
-exports.test  = gulp.series(exports.build, testMocha, testTestcafe);
+exports.clean     = clean;
+exports.lint      = lint;
+exports.build     = gulp.parallel(lint, gulp.series(clean, build));
+exports.test      = gulp.series(exports.build, testMocha, testTestcafe);
 exports.testMocha = gulp.series(exports.build, testMocha);
 
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Use the following environment variables to set additional configuration options:
 
  - `SAUCE_BUILD` - the text that will be displayed as Build Name on SauceLabs.
 
- - `SAUCE_CONFIG_PATH` - Path to a file which contains additional job options as JSON. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions) for a full list.
+ - `SAUCE_CONFIG_PATH` - path to a file which contains additional **job options** as JSON. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-TestAnnotation) for a full list.
+ 
+ - `SAUCE_CAPABILITIES_OVERRIDES_PATH` - path to a file that contains overrides for capabilities. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options) for details.
  
  - `SAUCE_SCREEN_RESOLUTION` - allows setting the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information. 
  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ clone_depth: 1
 
 environment:
   matrix:
-    - nodejs_version: "6"
+    - nodejs_version: "8"
     - nodejs_version: "stable"
 
 install:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-saucelabs",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "saucelabs TestCafe browser provider plugin.",
   "repository": "https://github.com/DevExpress/testcafe-browser-provider-saucelabs",
   "homepage": "https://github.com/DevExpress/testcafe-browser-provider-saucelabs",
@@ -51,7 +51,9 @@
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^3.0.1",
     "mocha": "^5.2.0",
+    "mock-fs": "^4.8.0",
     "publish-please": "^5.4.3",
+    "sinon": "^7.2.5",
     "testcafe": "^0.23.3",
     "tmp": "0.0.28"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import parseCapabilities from 'desired-capabilities';
-import * as fs from 'fs';
-import { assign, find, flatten } from 'lodash';
-import pify from 'pify';
-import Promise from 'pinkie';
-import requestAPI from 'request';
 import SauceLabsConnector from 'saucelabs-connector';
+import parseCapabilities from 'desired-capabilities';
+import requestAPI from 'request';
+import Promise from 'pinkie';
+import pify from 'pify';
+import { flatten, find, assign } from 'lodash';
+import * as fs from 'fs';
 
 const AUTH_FAILED_ERROR = 'Authentication failed. Please assign the correct username and access key ' +
                           'to the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables.';

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -28,10 +28,10 @@ describe('Browser names', function () {
                     'Internet Explorer@10.0:Windows 8',
                     'Internet Explorer@11.0:Windows 8.1',
                     'MicrosoftEdge@13.10586:Windows 10',
-                    'Samsung Galaxy S4 Emulator@4.4',
-                    'Android Emulator Phone@4.4',
-                    'iPad Simulator@9.3',
-                    'iPhone Simulator@9.3'
+                    'Samsung Galaxy Tab S3 GoogleAPI Emulator@8.1',
+                    'Android Emulator Phone@8.0',
+                    'iPad Simulator@13.0',
+                    'iPhone Simulator@13.0'
                 ];
 
                 var areBrowsersInList = commonBrowsers
@@ -54,7 +54,7 @@ describe('Browser names', function () {
             'IE@10.0:Windows 8',
             'IE@11:Windows 10',
             'iPhone Simulator@9.2',
-            'Android Emulator Tablet@4.4',
+            'Android Emulator Tablet@8.0',
             'IE@5.0',
             'IE@11:Linux'
         ];

--- a/test/mocha/generate-capabilities-test.js
+++ b/test/mocha/generate-capabilities-test.js
@@ -1,0 +1,73 @@
+const expect = require('chai').expect;
+const mockfs = require('mock-fs');
+const sandbox = require('sinon').createSandbox();
+const provider = require('../../');
+
+describe('Internal generateCapabilities test', function () {
+    const desktopUA = 'Chrome@51.0:OS X 10.10';
+
+    before(function () {
+        this.timeout(20000);
+        return provider.init();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        mockfs.restore();
+    });
+
+    after(function () {
+        return provider.dispose();
+    });
+
+    it('should generate basic desktop capabilities', function () {
+        const result = provider._generateCapabilities(desktopUA);
+
+        expect(result).eql({
+            browserName: 'chrome',
+            version:     '51.0',
+            platform:    'os x 10.10'
+        });
+    });
+
+    it('should set the screen resolution from SAUCE_SCREEN_RESOLUTION', function () {
+        sandbox.stub(process, 'env').value({ 'SAUCE_SCREEN_RESOLUTION': '1920x1200' });
+
+        const result = provider._generateCapabilities(desktopUA);
+
+        expect(result).eql({
+            browserName:      'chrome',
+            version:          '51.0',
+            platform:         'os x 10.10',
+            screenResolution: '1920x1200'
+        });
+    });
+
+    it('should provide capabilities overrides from file', function () {
+        sandbox.stub(process, 'env').value({ 'SAUCE_CAPABILITIES_OVERRIDES_PATH': 'overrides.json' });
+        mockfs({
+            'overrides.json': JSON.stringify({ extendedDebugging: true })
+        });
+
+        const result = provider._generateCapabilities(desktopUA);
+
+        expect(result).eql({
+            browserName:       'chrome',
+            version:           '51.0',
+            platform:          'os x 10.10',
+            extendedDebugging: true
+        });
+    });
+
+    it('should not override anything if overrides file does not exist', function () {
+        sandbox.stub(process, 'env').value({ 'SAUCE_CAPABILITIES_OVERRIDES_PATH': 'overrides.json' });
+
+        const result = provider._generateCapabilities(desktopUA);
+
+        expect(result).eql({
+            browserName: 'chrome',
+            version:     '51.0',
+            platform:    'os x 10.10'
+        });
+    });
+});

--- a/test/mocha/generate-capabilities-test.js
+++ b/test/mocha/generate-capabilities-test.js
@@ -20,8 +20,8 @@ describe('Internal generateCapabilities test', function () {
         return provider.dispose();
     });
 
-    it('should generate basic desktop capabilities', function () {
-        const result = provider._generateCapabilities(desktopUA);
+    it('should generate basic desktop capabilities', async function () {
+        const result = await provider._generateCapabilities(desktopUA);
 
         expect(result).eql({
             browserName: 'chrome',
@@ -30,10 +30,10 @@ describe('Internal generateCapabilities test', function () {
         });
     });
 
-    it('should set the screen resolution from SAUCE_SCREEN_RESOLUTION', function () {
+    it('should set the screen resolution from SAUCE_SCREEN_RESOLUTION', async function () {
         sandbox.stub(process, 'env').value({ 'SAUCE_SCREEN_RESOLUTION': '1920x1200' });
 
-        const result = provider._generateCapabilities(desktopUA);
+        const result = await provider._generateCapabilities(desktopUA);
 
         expect(result).eql({
             browserName:      'chrome',
@@ -43,13 +43,13 @@ describe('Internal generateCapabilities test', function () {
         });
     });
 
-    it('should provide capabilities overrides from file', function () {
+    it('should provide capabilities overrides from file', async function () {
         sandbox.stub(process, 'env').value({ 'SAUCE_CAPABILITIES_OVERRIDES_PATH': 'overrides.json' });
         mockfs({
             'overrides.json': JSON.stringify({ extendedDebugging: true })
         });
 
-        const result = provider._generateCapabilities(desktopUA);
+        const result = await provider._generateCapabilities(desktopUA);
 
         expect(result).eql({
             browserName:       'chrome',
@@ -59,10 +59,10 @@ describe('Internal generateCapabilities test', function () {
         });
     });
 
-    it('should not override anything if overrides file does not exist', function () {
+    it('should not override anything if overrides file does not exist', async function () {
         sandbox.stub(process, 'env').value({ 'SAUCE_CAPABILITIES_OVERRIDES_PATH': 'overrides.json' });
 
-        const result = provider._generateCapabilities(desktopUA);
+        const result = await provider._generateCapabilities(desktopUA);
 
         expect(result).eql({
             browserName: 'chrome',


### PR DESCRIPTION
This PR enables support for overriding **capabilities**.  The existing `SAUCE_CONFIG_PATH` just sets **job options**, which is just a subset of configuration options, while this change allows consumers to override all sorts of SauceLabs options, such as `extendedDebugging` and `screenResolution`, with a single configuration file.

In the long run, I think the `SAUCE_CONFIG_PATH` option could be renamed and the `SAUCE_SCREEN_RESOLUTION` var could be removed, but those are potentially breaking changes I didn't want to make in this context.