### PR TITLE
Feature/enable connector options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ Use the following environment variables to set additional configuration options:
  - `SAUCE_BUILD` - the text that will be displayed as Build Name on SauceLabs.
 
  - `SAUCE_CONFIG_PATH` - Path to a file which contains additional job options as JSON. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions) for a full list.
- 
- - `SAUCE_SCREEN_RESOLUTION` - allows setting the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information. 
- 
+
+ - `SAUCE_CONNECTOR_CONFIG_PATH` - Path to a file which contains additional connector options as JSON. additionalArg: "foo" options will be converted to --addtional-arg foo args (camelCase to kebab-case). Additional option starting with dash "-additionalArg": "foo" will be passed as it is -additionalArg foo. Arrays will be joined (like directDomains) and boolean options will be passed as flags. See [Sauce Connect's docs](https://docs.saucelabs.com/reference/sauce-connect) for a full list of arguments.
+
+ - `SAUCE_SCREEN_RESOLUTION` - allows setting the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information.
+
 Example:
 ```sh
 export SAUCE_SCREEN_RESOLUTION="1920x1080"
@@ -54,6 +56,6 @@ export SAUCE_JOB="E2E TestCafe"
 export SAUCE_BUILD="Build 42"
 testcafe saucelabs:safari,saucelabs:chrome tests/
 ```
- 
+
 ## Author
 Developer Express Inc. (https://devexpress.com)

--- a/src/index.js
+++ b/src/index.js
@@ -178,8 +178,6 @@ export default {
                 if (!connector) {
                     var sauceConnectorOptions = process.env['SAUCE_CONNECTOR_CONFIG_PATH'] ? await getAdditionalConfig(process.env['SAUCE_CONNECTOR_CONFIG_PATH']) : {};
 
-                    sauceConnectorOptions['connectorLogging'] = sauceConnectorOptions['connectorLogging'] || false;
-
                     connector = new SauceLabsConnector(process.env['SAUCE_USERNAME'], process.env['SAUCE_ACCESS_KEY'], sauceConnectorOptions);
 
                     await connector.connect();

--- a/src/index.js
+++ b/src/index.js
@@ -176,9 +176,11 @@ export default {
         this.connectorPromise = this.connectorPromise
             .then(async connector => {
                 if (!connector) {
-                    connector = new SauceLabsConnector(process.env['SAUCE_USERNAME'], process.env['SAUCE_ACCESS_KEY'], {
-                        connectorLogging: false
-                    });
+                    var sauceConnectorOptions = process.env['SAUCE_CONNECTOR_CONFIG_PATH'] ? await getAdditionalConfig(process.env['SAUCE_CONNECTOR_CONFIG_PATH']) : {};
+
+                    sauceConnectorOptions['connectorLogging'] = sauceConnectorOptions['connectorLogging'] || false;
+
+                    connector = new SauceLabsConnector(process.env['SAUCE_USERNAME'], process.env['SAUCE_ACCESS_KEY'], sauceConnectorOptions);
 
                     await connector.connect();
                 }


### PR DESCRIPTION
Added functionality to pass SauceProxy connector options. 

Our use cases:
- we run testcafe via corporate proxy, therefore SC tunnel requires --tunnel-proxy flag
- we need to add --no-ssl-bump-domains 'all' set to avoid ssl issues