### PR TITLE
Ignore *.log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 lib
 node_modules
 package-lock.json
+*.log


### PR DESCRIPTION
This change fixes the "Checking for the untracked files" `publish-please` check. After completing the tests we have Sauce Connect `*.log` files that should not be tracked.