### PR TITLE
Migrate asset retrieval to platforms API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ If you run tests from the command line, use the browser alias when specifying br
 testcafe "saucelabs:Chrome@beta:Windows 10" 'path/to/test/file.js'
 ```
 
+If you leave out the browser version, it'll run against the latest stable version:
+
+```
+testcafe "saucelabs:Chrome:Windows 10" 'path/to/test/file.js'
+```
 
 When you use API, pass the alias to the `browsers()` method:
 
@@ -46,13 +51,13 @@ Use the following environment variables to set additional configuration options:
  - `SAUCE_CONFIG_PATH` - path to a file which contains additional **job options** as JSON. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-TestAnnotation) for a full list.
 
  - `SAUCE_CONNECT_OVERRIDES_PATH` - path to a file that overrides SauceLabs [connector options](https://github.com/DevExpress/saucelabs-connector). See [Sauce Connect launcher documentation](https://github.com/bermi/sauce-connect-launcher#advanced-usage) for more information.
- 
+
  - `SAUCE_CAPABILITIES_OVERRIDES_PATH` - path to a file that contains overrides for capabilities. See [SauceLabs Test Configuration](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options) for details.
- 
- - `SAUCE_SCREEN_RESOLUTION` - allows setting the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information. 
- 
+
+ - `SAUCE_SCREEN_RESOLUTION` - allows setting the screen resolution for desktop browsers in the `${width}x${height}` format, has no effect when specified for a mobile browser. See [Specifying the Screen Resolution](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-SpecifyingtheScreenResolution) for additional information.
+
  - `SAUCE_API_HOST` - if your SauceLabs account is registered in an EU country, you need to specify an EU-based data center, for instance, `eu-central-1.saucelabs.com`.
- 
+
 Example:
 ```sh
 export SAUCE_SCREEN_RESOLUTION="1920x1080"
@@ -60,6 +65,6 @@ export SAUCE_JOB="E2E TestCafe"
 export SAUCE_BUILD="Build 42"
 testcafe saucelabs:safari,saucelabs:chrome tests/
 ```
- 
+
 ## Author
 Developer Express Inc. (https://devexpress.com)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-saucelabs",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "saucelabs TestCafe browser provider plugin.",
   "repository": "https://github.com/DevExpress/testcafe-browser-provider-saucelabs",
   "homepage": "https://github.com/DevExpress/testcafe-browser-provider-saucelabs",

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -21,15 +21,11 @@ describe('Browser names', function () {
             .getBrowserList()
             .then(function (list) {
                 var commonBrowsers = [
-                    'Chrome@51.0:OS X 10.10',
-                    'Firefox@45.0:Linux',
-                    'Safari@9.0:OS X 10.11',
-                    'Internet Explorer@9.0:Windows 7',
-                    'Internet Explorer@10.0:Windows 8',
-                    'Internet Explorer@11.0:Windows 8.1',
-                    'MicrosoftEdge@13.10586:Windows 10',
-                    'Samsung Galaxy Tab S3 GoogleAPI Emulator@8.1',
-                    'Android Emulator Phone@8.0',
+                    'chrome@100:Mac 13',
+                    'safari@16:Mac 13',
+                    'MicrosoftEdge@110:Windows 11',
+                    'Samsung Galaxy S10 WQHD GoogleAPI Emulator@11.0',
+                    'Android GoogleAPI Emulator@12.0',
                     'iPad Simulator@13.0',
                     'iPhone Simulator@13.0'
                 ];
@@ -50,13 +46,13 @@ describe('Browser names', function () {
             'Opera:Linux',
             'Firefox',
             'MicrosoftEdge',
-            'IE@9',
-            'IE@10.0:Windows 8',
-            'IE@11:Windows 10',
+            'Internet Explorer@9',
+            'Internet Explorer@10:Windows 2008',
+            'Internet Explorer@11:Windows 10',
             'iPhone Simulator@9.2',
             'Android Emulator Tablet@8.0',
-            'IE@5.0',
-            'IE@11:Linux'
+            'Internet Explorer@5.0',
+            'Internet Explorer@11:Linux'
         ];
 
         var expectedResults = [

--- a/test/mocha/generate-capabilities-test.js
+++ b/test/mocha/generate-capabilities-test.js
@@ -3,7 +3,7 @@ const sandbox  = require('sinon').createSandbox();
 const provider = require('../../');
 
 describe('Internal generateCapabilities test', function () {
-    const desktopUA = 'Chrome@88.0:macOS 11.00';
+    const desktopUA = 'Chrome@88:Mac 13';
 
     before(function () {
         this.timeout(20000);
@@ -24,56 +24,56 @@ describe('Internal generateCapabilities test', function () {
                 desktopUA,
                 expected: {
                     browserName: 'chrome',
-                    version:     '88.0',
-                    platform:    'macos 11.00'
+                    version:     '88',
+                    platform:    'mac 13'
                 }
             },
             {
-                desktopUA: 'Chrome@88.0:macOS 10.15',
+                desktopUA: 'Chrome@88:mac 10.15',
                 expected:  {
                     browserName: 'chrome',
-                    version:     '88.0',
-                    platform:    'macos 10.15'
+                    version:     '88',
+                    platform:    'mac 10.15'
                 }
             },
             {
-                desktopUA: 'Chrome@88.0:macOS 10.14',
+                desktopUA: 'Chrome@88:mac 10.14',
                 expected:  {
                     browserName: 'chrome',
-                    version:     '88.0',
-                    platform:    'macos 10.14'
+                    version:     '88',
+                    platform:    'mac 10.14'
                 }
             },
             {
-                desktopUA: 'Chrome@88.0:macOS 10.13',
+                desktopUA: 'Chrome@88:mac 10.13',
                 expected:  {
                     browserName: 'chrome',
-                    version:     '88.0',
-                    platform:    'macos 10.13'
+                    version:     '88',
+                    platform:    'mac 10.13'
                 }
             },
             {
-                desktopUA: 'Chrome@88.0:macOS 10.12',
+                desktopUA: 'Chrome@88:mac 10.12',
                 expected:  {
                     browserName: 'chrome',
-                    version:     '88.0',
-                    platform:    'macos 10.12'
+                    version:     '88',
+                    platform:    'mac 10.12'
                 }
             },
             {
-                desktopUA: 'Chrome@88.0:OS X 10.11',
+                desktopUA: 'Chrome@88:mac 10.11',
                 expected:  {
                     browserName: 'chrome',
-                    version:     '88.0',
-                    platform:    'os x 10.11'
+                    version:     '88',
+                    platform:    'mac 10.11'
                 }
             },
             {
-                desktopUA: 'Chrome@87.0:OS X 10.10',
+                desktopUA: 'Chrome@87:mac 10.10',
                 expected:  {
                     browserName: 'chrome',
-                    version:     '87.0',
-                    platform:    'os x 10.10'
+                    version:     '87',
+                    platform:    'mac 10.10'
                 }
             }
         ];
@@ -94,8 +94,8 @@ describe('Internal generateCapabilities test', function () {
 
         expect(result).eql({
             browserName:      'chrome',
-            version:          '88.0',
-            platform:         'macos 11.00',
+            version:          '88',
+            platform:         'mac 13',
             screenResolution: '1920x1200'
         });
     });
@@ -107,8 +107,8 @@ describe('Internal generateCapabilities test', function () {
 
         expect(result).eql({
             browserName:       'chrome',
-            version:           '88.0',
-            platform:          'macos 11.00',
+            version:           '88',
+            platform:          'mac 13',
             extendedDebugging: true
         });
     });
@@ -120,8 +120,8 @@ describe('Internal generateCapabilities test', function () {
 
         expect(result).eql({
             browserName: 'chrome',
-            version:     '88.0',
-            platform:    'macos 11.00'
+            version:     '88',
+            platform:    'mac 13'
         });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/DevExpress/testcafe-browser-provider-saucelabs/issues/80 by migrating the source of truth from outdated assets stored in the Sauce Labs wiki to the actual [platforms API](https://docs.saucelabs.com/dev/api/platform/#get-supported-platforms).


The code follows the API much closer in nature now, which brings us some **breaking changes**:


- The "IE" browser alias is no longer supported.
- `macOS` and `OS X` platform alias is now simply `mac`.
- Browser versions that do not need a decimal point, don't have one. For example, prior to this change Chrome 80 would be specified as `Chrome@80.0`. Now it's `Chrome@80`.