### PR TITLE
fix: get rid of `request` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     "babel-runtime": "^6.11.6",
     "desired-capabilities": "^0.1.0",
     "lodash": "^4.14.2",
-    "pify": "^2.3.0",
     "pinkie": "^2.0.4",
-    "request": "^2.74.0",
     "saucelabs-connector": "^1.1.0"
   },
   "devDependencies": {

--- a/src/https-request.js
+++ b/src/https-request.js
@@ -1,14 +1,16 @@
 import https from 'https';
 
-export function getRequest (url, user, password) {
+export function httpsRequest ({ hostname, path, user, password }) {
     const options = {
+        hostname,
+        path,
         headers: {
             'Authorization': 'Basic ' + new Buffer(user + ':' + password).toString('base64')
         }
     };
 
     return new Promise((resolve, reject) => {
-        const request = https.get(url, options, response => {
+        const request = https.get(options, response => {
             let data = '';
     
             response.on('data', chunk => {

--- a/src/https-request.js
+++ b/src/https-request.js
@@ -12,7 +12,7 @@ export function httpsRequest ({ hostname, path, user, password }) {
     return new Promise((resolve, reject) => {
         const request = https.get(options, response => {
             let data = '';
-    
+
             response.on('data', chunk => {
                 data += chunk.toString('utf8');
             });

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Promise from 'pinkie';
 import util from 'util';
 import { assign } from 'lodash';
 import * as fs from 'fs';
-import { getRequest } from './promisified-get-request';
+import { httpsRequest } from './https-request';
 
 const AUTH_FAILED_ERROR = 'Authentication failed. Please assign the correct username and access key ' +
                           'to the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables.';
@@ -35,7 +35,12 @@ async function fetchPlatforms () {
         throw new Error(AUTH_FAILED_ERROR);
 
     const host = process.env.SAUCE_API_HOST || 'us-west-1.saucelabs.com';
-    const response = await getRequest(`https://api.${host}/rest/v1.1/info/platforms/all`, process.env['SAUCE_USERNAME'], process.env['SAUCE_ACCESS_KEY']);
+    const response = await httpsRequest({
+        hostname: `api.${host}`,
+        path:     '/rest/v1.1/info/platforms/all',
+        user:     process.env['SAUCE_USERNAME'],
+        password: process.env['SAUCE_ACCESS_KEY']
+    });
 
     try {
         return JSON.parse(response.body);

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
 import SauceLabsConnector from 'saucelabs-connector';
 import parseCapabilities from 'desired-capabilities';
-import requestAPI from 'request';
 import Promise from 'pinkie';
-import pify from 'pify';
 import util from 'util';
 import { assign } from 'lodash';
 import * as fs from 'fs';
+import { getRequest } from './promisified-get-request';
 
 const AUTH_FAILED_ERROR = 'Authentication failed. Please assign the correct username and access key ' +
                           'to the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables.';
@@ -15,8 +14,6 @@ const WAIT_FOR_FREE_MACHINES_REQUEST_INTERVAL  = 60000;
 const WAIT_FOR_FREE_MACHINES_MAX_ATTEMPT_COUNT = 45;
 const MAX_TUNNEL_CONNECT_RETRY_COUNT           = 3;
 
-const promisify = fn => pify(fn, Promise);
-const request   = promisify(requestAPI, Promise);
 const readFile  = util.promisify(fs.readFile);
 
 const isDesktop = platformInfo => platformInfo.platformGroup === 'Desktop';
@@ -38,13 +35,7 @@ async function fetchPlatforms () {
         throw new Error(AUTH_FAILED_ERROR);
 
     const host = process.env.SAUCE_API_HOST || 'us-west-1.saucelabs.com';
-    const response = await request(`https://api.${host}/rest/v1.1/info/platforms/all`,
-        {
-            'auth': {
-                'user': process.env['SAUCE_USERNAME'],
-                'pass': process.env['SAUCE_ACCESS_KEY']
-            }
-        });
+    const response = await getRequest(`https://api.${host}/rest/v1.1/info/platforms/all`, process.env['SAUCE_USERNAME'], process.env['SAUCE_ACCESS_KEY']);
 
     try {
         return JSON.parse(response.body);

--- a/src/promisified-get-request.js
+++ b/src/promisified-get-request.js
@@ -1,13 +1,7 @@
 import https from 'https';
-import { parse as parseUrl } from 'url';
 
 export function getRequest (url, user, password) {
-    const { hostname, port, path } = parseUrl(url);
-
     const options = {
-        hostname,
-        port,
-        path,
         headers: {
             'Authorization': 'Basic ' + new Buffer(user + ':' + password).toString('base64')
         }

--- a/src/promisified-get-request.js
+++ b/src/promisified-get-request.js
@@ -1,0 +1,38 @@
+import https from 'https';
+import { parse as parseUrl } from 'url';
+
+export function getRequest (url, user, password) {
+    const { hostname, port, path } = parseUrl(url);
+
+    const options = {
+        hostname,
+        port,
+        path,
+        headers: {
+            'Authorization': 'Basic ' + new Buffer(user + ':' + password).toString('base64')
+        }
+    };
+
+    return new Promise((resolve, reject) => {
+        const request = https.get(url, options, response => {
+            let data = '';
+    
+            response.on('data', chunk => {
+                data += chunk.toString('utf8');
+            });
+
+            response.on('end', () => {
+                const { statusCode, statusMessage } = response;
+
+                if (statusCode >= 200 && statusCode <= 299)
+                    resolve({ body: data });
+                else
+                    reject({ statusCode, statusMessage });
+            });
+
+            response.on('error', reject);
+        });
+
+        request.on('error', reject);
+    });
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
+    "comma-dangle": ["error", "always-multiline"],
     "no-unused-expressions": 0,
     "max-nested-callbacks": ["error", 4]
   },

--- a/test/mocha/browser-names-test.js
+++ b/test/mocha/browser-names-test.js
@@ -27,7 +27,7 @@ describe('Browser names', function () {
                     'Samsung Galaxy S10 WQHD GoogleAPI Emulator@11.0',
                     'Android GoogleAPI Emulator@12.0',
                     'iPad Simulator@13.0',
-                    'iPhone Simulator@13.0'
+                    'iPhone Simulator@13.0',
                 ];
 
                 var areBrowsersInList = commonBrowsers
@@ -52,7 +52,7 @@ describe('Browser names', function () {
             'iPhone Simulator@9.2',
             'Android Emulator Tablet@8.0',
             'Internet Explorer@5.0',
-            'Internet Explorer@11:Linux'
+            'Internet Explorer@11:Linux',
         ];
 
         var expectedResults = [
@@ -67,7 +67,7 @@ describe('Browser names', function () {
             false,
             true,
             false,
-            false
+            false,
         ];
 
         var validationPromises = browserNames

--- a/test/mocha/generate-capabilities-test.js
+++ b/test/mocha/generate-capabilities-test.js
@@ -25,57 +25,57 @@ describe('Internal generateCapabilities test', function () {
                 expected: {
                     browserName: 'chrome',
                     version:     '88',
-                    platform:    'mac 13'
-                }
+                    platform:    'mac 13',
+                },
             },
             {
                 desktopUA: 'Chrome@88:mac 10.15',
                 expected:  {
                     browserName: 'chrome',
                     version:     '88',
-                    platform:    'mac 10.15'
-                }
+                    platform:    'mac 10.15',
+                },
             },
             {
                 desktopUA: 'Chrome@88:mac 10.14',
                 expected:  {
                     browserName: 'chrome',
                     version:     '88',
-                    platform:    'mac 10.14'
-                }
+                    platform:    'mac 10.14',
+                },
             },
             {
                 desktopUA: 'Chrome@88:mac 10.13',
                 expected:  {
                     browserName: 'chrome',
                     version:     '88',
-                    platform:    'mac 10.13'
-                }
+                    platform:    'mac 10.13',
+                },
             },
             {
                 desktopUA: 'Chrome@88:mac 10.12',
                 expected:  {
                     browserName: 'chrome',
                     version:     '88',
-                    platform:    'mac 10.12'
-                }
+                    platform:    'mac 10.12',
+                },
             },
             {
                 desktopUA: 'Chrome@88:mac 10.11',
                 expected:  {
                     browserName: 'chrome',
                     version:     '88',
-                    platform:    'mac 10.11'
-                }
+                    platform:    'mac 10.11',
+                },
             },
             {
                 desktopUA: 'Chrome@87:mac 10.10',
                 expected:  {
                     browserName: 'chrome',
                     version:     '87',
-                    platform:    'mac 10.10'
-                }
-            }
+                    platform:    'mac 10.10',
+                },
+            },
         ];
 
         const promises = testCases.map(async testCase => {
@@ -96,7 +96,7 @@ describe('Internal generateCapabilities test', function () {
             browserName:      'chrome',
             version:          '88',
             platform:         'mac 13',
-            screenResolution: '1920x1200'
+            screenResolution: '1920x1200',
         });
     });
 
@@ -109,7 +109,7 @@ describe('Internal generateCapabilities test', function () {
             browserName:       'chrome',
             version:           '88',
             platform:          'mac 13',
-            extendedDebugging: true
+            extendedDebugging: true,
         });
     });
 
@@ -121,7 +121,7 @@ describe('Internal generateCapabilities test', function () {
         expect(result).eql({
             browserName: 'chrome',
             version:     '88',
-            platform:    'mac 13'
+            platform:    'mac 13',
         });
     });
 });

--- a/test/mocha/generate-sauce-connect-options-test.js
+++ b/test/mocha/generate-sauce-connect-options-test.js
@@ -30,7 +30,7 @@ describe('Internal generateSauceConnectOptions test', function () {
         expect(result).eql({
             connectorLogging: false,
             directDomains:    ['*.google.com'], 
-            noSslBumpDomains: 'all'
+            noSslBumpDomains: 'all',
         });
     });
 
@@ -40,7 +40,7 @@ describe('Internal generateSauceConnectOptions test', function () {
         const result = await provider._generateSauceConnectOptions();
 
         expect(result).eql({
-            connectorLogging: false
+            connectorLogging: false,
         });
     });
 });

--- a/test/mocha/useragent-test.js
+++ b/test/mocha/useragent-test.js
@@ -30,7 +30,7 @@ describe('Useragent info', function () {
                 },
                 end: function (data) {
                     report += data;
-                }
+                },
             })
             .run()
             .then(function (failedCount) {

--- a/test/testcafe/resize-test.js
+++ b/test/testcafe/resize-test.js
@@ -7,14 +7,14 @@ fixture `Resize`
 test('Resize test', async t => {
     var originalSize = await t.eval(() => ({
         width:  window.innerWidth,
-        height: window.innerHeight
+        height: window.innerHeight,
     }));
 
     await t.resizeWindow(500, 500);
 
     var newSize = await t.eval(() => ({
         width:  window.innerWidth,
-        height: window.innerHeight
+        height: window.innerHeight,
     }));
 
     expect(newSize.width).to.be.not.equal(originalSize.width);


### PR DESCRIPTION
The `https.get` NodeJS API used instead of `request` dependency
