### PR TITLE
Build: fix test-mac

### DIFF
--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -79,6 +79,7 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          SAUCE_CONNECT_VERSION: ${{ secrets.SAUCE_CONNECT_VERSION }}
       - uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
`sauce-connect-launcher` uses the latest version obtained from JSON. Then, it attempts to download the Sauce Connector Launcher, substituting the version provided in JSON. However, there is [no version 4.9.2 for macOS](https://docs.saucelabs.com/secure-connections/sauce-connect/installation/#downloading-sauce-connect-proxy). To address the issue, we add an environment variable and specify the latest version for macOS.

success test with changes: [test](https://github.com/PavelMor25/testcafe-browser-provider-saucelabs/actions/runs/7345955800/job/20000182831)

closes DevExpress/testcafe-private#441






